### PR TITLE
Shader export fix for duplicate node definitions

### DIFF
--- a/Assets/GPUGraph/Editor/Graph System/Graph.cs
+++ b/Assets/GPUGraph/Editor/Graph System/Graph.cs
@@ -252,8 +252,13 @@ namespace GPUGraph
                 //Otherwise, let the node emit its code and then remove it from the stack.
                 else
                 {
-                    toProcess.RemoveAt(toProcess.Count - 1);
-                    n.EmitCode(body);
+					toProcess.RemoveAt(toProcess.Count - 1);
+					
+					//Fixes duplicate variable definitions for nodes with branching paths.
+					if( body.ToString().Contains("float "+n.OutputName+" =" ) )
+						continue;
+					else
+                    	n.EmitCode(body);
                 }
             }
 


### PR DESCRIPTION
Fixes issue: https://github.com/heyx3/GPUNoiseForUnity/issues/1